### PR TITLE
add `session` table migration (PR tl-its-umich-edu/docker-base-images#11)

### DIFF
--- a/canvas-peer-grade-calculator/Dockerfile.umich
+++ b/canvas-peer-grade-calculator/Dockerfile.umich
@@ -2,3 +2,9 @@ FROM ghcr.io/longhornopen/canvaspeergrade:20221219
 
 # https://documentation.its.umich.edu/node/2118
 RUN useradd -g root -m -s /bin/bash -l -o -u 1000940000 www-root
+
+# Copy any local migrations
+COPY migrations/*.php /var/www/html/database/migrations/
+
+# Fix up the files
+RUN chown -R www-data:www-data /var/www/html

--- a/canvas-peer-grade-calculator/migrations/2023_03_02_195645_create_sessions_table.php
+++ b/canvas-peer-grade-calculator/migrations/2023_03_02_195645_create_sessions_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('sessions', function (Blueprint $table) {
+            $table->string('id')->primary();
+            $table->foreignId('user_id')->nullable()->index();
+            $table->string('ip_address', 45)->nullable();
+            $table->text('user_agent')->nullable();
+            $table->longText('payload');
+            $table->integer('last_activity')->index();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('sessions');
+    }
+};


### PR DESCRIPTION
This is @jonespm's recommendation for adding a `session` migration to the project. It is copied into the container with the others.  This should eliminate problems with using the Artisan command to create the migration on request.  A later step in `Dockerfile.umich` would apply that along with the other migrations.